### PR TITLE
Move ProfitRecorder to Account package - Output win rate for each data set at end of simulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Created by .ignore support plugin (hsz.mobi)
 .idea/*
 target/
+test-output/
 src/main/main.iml
 genotick-standalone.iml
 

--- a/src/main/java/com/alphatica/genotick/account/Account.java
+++ b/src/main/java/com/alphatica/genotick/account/Account.java
@@ -80,7 +80,8 @@ public class Account {
 
     private void closeTrade(DataSetName name, BigDecimal price) {
         ofNullable(trades.get(name)).ifPresent(trade -> {
-            BigDecimal profit = trade.getQuantity().multiply(price.subtract(trade.getPrice()));
+            BigDecimal priceDifference = price.subtract(trade.getPrice());
+            BigDecimal profit = trade.getQuantity().multiply(priceDifference);
             BigDecimal initial = trade.getQuantity().abs().multiply(trade.getPrice());
             cash = cash.add(profit).add(initial);
             output.reportClosingTrade(name, trade.getQuantity(), price, profit, cash);

--- a/src/main/java/com/alphatica/genotick/account/ProfitRecorder.java
+++ b/src/main/java/com/alphatica/genotick/account/ProfitRecorder.java
@@ -20,6 +20,11 @@ public class ProfitRecorder {
     private final Map<DataSetName, Integer> wins = new HashMap<>();
     private final Map<DataSetName, Integer> losses = new HashMap<>();
     private final Set<DataSetName> names = new HashSet<>();
+    private final UserOutput output;
+    
+    public ProfitRecorder(UserOutput output) {
+        this.output = output;
+    }
     
     void addTradeResult(DataSetName name, double profit) {
         names.add(name);
@@ -99,8 +104,7 @@ public class ProfitRecorder {
         int incorrect = ofNullable(losses.get(name)).orElse(0);
         if(correct + incorrect > 0) {
             double percentCorrect = (double) correct / (correct + incorrect) * 100;
-            UserOutput output = UserInputOutputFactory.getUserOutput();
-            output.infoMessage(format("Win rate for %s: %f %%", name.getPath(), percentCorrect));
+            output.infoMessage(format("Win rate for %s: %.2f %%", name.getPath(), percentCorrect));
         }
     }
 }

--- a/src/main/java/com/alphatica/genotick/account/ProfitRecorder.java
+++ b/src/main/java/com/alphatica/genotick/account/ProfitRecorder.java
@@ -3,7 +3,6 @@ package com.alphatica.genotick.account;
 import com.alphatica.genotick.data.DataSetName;
 import com.alphatica.genotick.ui.UserInputOutputFactory;
 import com.alphatica.genotick.ui.UserOutput;
-import com.alphatica.genotick.genotick.Outcome;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -16,22 +15,20 @@ import java.util.Set;
 import static java.lang.String.format;
 import static java.util.Optional.ofNullable;
 
-class ProfitRecorder {
+public class ProfitRecorder {
     private final List<Double> profits = new ArrayList<>();
     private final Map<DataSetName, Integer> wins = new HashMap<>();
     private final Map<DataSetName, Integer> losses = new HashMap<>();
     private final Set<DataSetName> names = new HashSet<>();
     
-    public void addTradeResult(DataSetName name, Outcome outcome, double profit) {
+    void addTradeResult(DataSetName name, double profit) {
         names.add(name);
-        if (Outcome.OUT != outcome) {
-            if (Outcome.CORRECT == outcome) {
-                wins.merge(name, 1, Integer::sum);
-            }
-            else if (Outcome.INCORRECT == outcome) {
-                losses.merge(name, 1, Integer::sum);
-            }
-            profits.add(profit);
+        profits.add(profit);
+        if (profit > 0) {
+            wins.merge(name, 1, Integer::sum);
+        }
+        else {
+            losses.merge(name, 1, Integer::sum);
         }
     }
     
@@ -90,7 +87,7 @@ class ProfitRecorder {
     }
     
     void outputWinRateForAllRecords() {
-        outputWinRate(this.names);
+        outputWinRate(names);
     }
 
     void outputWinRate(Collection<DataSetName> names) {

--- a/src/main/java/com/alphatica/genotick/account/ProfitRecorder.java
+++ b/src/main/java/com/alphatica/genotick/account/ProfitRecorder.java
@@ -16,6 +16,7 @@ import static java.lang.String.format;
 import static java.util.Optional.ofNullable;
 
 public class ProfitRecorder {
+
     private final List<Double> profits = new ArrayList<>();
     private final Map<DataSetName, Integer> wins = new HashMap<>();
     private final Map<DataSetName, Integer> losses = new HashMap<>();
@@ -32,7 +33,7 @@ public class ProfitRecorder {
         if (profit > 0) {
             wins.merge(name, 1, Integer::sum);
         }
-        else {
+        else if (profit < 0) {
             losses.merge(name, 1, Integer::sum);
         }
     }
@@ -104,7 +105,18 @@ public class ProfitRecorder {
         int incorrect = ofNullable(losses.get(name)).orElse(0);
         if(correct + incorrect > 0) {
             double percentCorrect = (double) correct / (correct + incorrect) * 100;
-            output.infoMessage(format("Win rate for %s: %.2f %%", name.getPath(), percentCorrect));
+            output.infoMessage(getWinRateFormat(name, percentCorrect));
         }
+        else {
+            output.infoMessage(getNoWinRateFormat(name));
+        }
+    }
+    
+    public static String getWinRateFormat(DataSetName name, double percentCorrect) {
+        return String.format("Win rate for %s: %.2f %%", name.getPath(), percentCorrect);
+    }
+    
+    public static String getNoWinRateFormat(DataSetName name) {
+        return String.format("No win rate for %s", name.getPath());
     }
 }

--- a/src/main/java/com/alphatica/genotick/account/Trade.java
+++ b/src/main/java/com/alphatica/genotick/account/Trade.java
@@ -2,13 +2,11 @@ package com.alphatica.genotick.account;
 
 import lombok.Value;
 import java.math.BigDecimal;
-import com.alphatica.genotick.genotick.Prediction;
 
 @Value
 class Trade {
     private BigDecimal quantity;
     private BigDecimal price;
-    private Prediction prediction;
 
     BigDecimal value() {
         return quantity.abs().multiply(price);

--- a/src/main/java/com/alphatica/genotick/account/Trade.java
+++ b/src/main/java/com/alphatica/genotick/account/Trade.java
@@ -2,11 +2,13 @@ package com.alphatica.genotick.account;
 
 import lombok.Value;
 import java.math.BigDecimal;
+import com.alphatica.genotick.genotick.Prediction;
 
 @Value
 class Trade {
     private BigDecimal quantity;
     private BigDecimal price;
+    private Prediction prediction;
 
     BigDecimal value() {
         return quantity.abs().multiply(price);

--- a/src/main/java/com/alphatica/genotick/genotick/RobotData.java
+++ b/src/main/java/com/alphatica/genotick/genotick/RobotData.java
@@ -7,12 +7,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class RobotData {
-    private final List<double[]> data;
-    private final double lastChange;
+    private final List<double[]> priceData;
+    private final double lastPriceChange;
     private final DataSetName name;
 
-    public static RobotData createData(List<double[]> newData, DataSetName name) {
-        return new RobotData(newData, name);
+    public static RobotData createData(List<double[]> priceData, DataSetName name) {
+        return new RobotData(priceData, name);
     }
 
     public static RobotData createEmptyData(DataSetName name) {
@@ -21,21 +21,21 @@ public class RobotData {
         return createData(list, name);
     }
 
-    private RobotData(List<double[]> newData, DataSetName name) {
-        data = newData;
+    private RobotData(List<double[]> priceData, DataSetName name) {
+        this.priceData = priceData;
         this.name = name;
-        this.lastChange = calculateLastChange(newData);
+        this.lastPriceChange = calculateLastPriceChange(priceData);
     }
 
-    public double getLastChange() {
-        return lastChange;
+    public double getLastPriceChange() {
+        return lastPriceChange;
     }
 
     public double getData(int dataColumn, int dataOffset) {
-        if (dataOffset >= data.get(dataColumn).length)
+        if (dataOffset >= priceData.get(dataColumn).length)
             throw new NotEnoughDataException();
         else
-            return data.get(dataColumn)[dataOffset];
+            return priceData.get(dataColumn)[dataOffset];
     }
 
     public DataSetName getName() {
@@ -43,27 +43,27 @@ public class RobotData {
     }
 
     public boolean isEmpty() {
-        return data.get(0).length == 0;
+        return priceData.get(0).length == 0;
     }
 
     public int getColumns() {
-        return data.size();
+        return priceData.size();
     }
 
     public double getLastOpen() {
-        return data.get(0)[0];
+        return priceData.get(0)[0];
     }
 
-    private static double calculateLastChange(List<double[]> newData) {
-        if(newData.get(0).length < 2) {
+    private static double calculateLastPriceChange(List<double[]> priceData) {
+        if(priceData.get(0).length < 2) {
             return 0;
         }
-        double last = newData.get(0)[0];
-        double previous = newData.get(0)[1];
-        return calculateLastChange(last, previous);
+        double last = priceData.get(0)[0];
+        double previous = priceData.get(0)[1];
+        return calculateLastPriceChange(last, previous);
     }
     
-    public static double calculateLastChange(double last, double previous) {
+    public static double calculateLastPriceChange(double last, double previous) {
         return 100 * (last - previous) / previous;
     }
 }

--- a/src/main/java/com/alphatica/genotick/genotick/RobotData.java
+++ b/src/main/java/com/alphatica/genotick/genotick/RobotData.java
@@ -31,7 +31,7 @@ public class RobotData {
         return lastPriceChange;
     }
 
-    public double getData(int dataColumn, int dataOffset) {
+    public double getPriceData(int dataColumn, int dataOffset) {
         if (dataOffset >= priceData.get(dataColumn).length)
             throw new NotEnoughDataException();
         else
@@ -50,7 +50,7 @@ public class RobotData {
         return priceData.size();
     }
 
-    public double getLastOpen() {
+    double getLastPriceOpen() {
         return priceData.get(0)[0];
     }
 
@@ -60,10 +60,6 @@ public class RobotData {
         }
         double last = priceData.get(0)[0];
         double previous = priceData.get(0)[1];
-        return calculateLastPriceChange(last, previous);
-    }
-    
-    public static double calculateLastPriceChange(double last, double previous) {
         return 100 * (last - previous) / previous;
     }
 }

--- a/src/main/java/com/alphatica/genotick/genotick/RobotData.java
+++ b/src/main/java/com/alphatica/genotick/genotick/RobotData.java
@@ -27,6 +27,7 @@ public class RobotData {
         this.lastChange = calculateLastChange(newData);
     }
 
+    // lastChange is the difference of the previous price to the current price
     public double getLastChange() {
         return lastChange;
     }
@@ -50,16 +51,20 @@ public class RobotData {
         return data.size();
     }
 
-    double getLastOpen() {
+    public double getLastOpen() {
         return data.get(0)[0];
     }
 
-    private double calculateLastChange(List<double[]> newData) {
-        if(data.get(0).length < 2) {
+    private static double calculateLastChange(List<double[]> newData) {
+        if(newData.get(0).length < 2) {
             return 0;
         }
         double last = newData.get(0)[0];
         double previous = newData.get(0)[1];
+        return calculateLastChange(last, previous);
+    }
+    
+    public static double calculateLastChange(double last, double previous) {
         return 100 * (last - previous) / previous;
     }
 }

--- a/src/main/java/com/alphatica/genotick/genotick/RobotData.java
+++ b/src/main/java/com/alphatica/genotick/genotick/RobotData.java
@@ -27,7 +27,6 @@ public class RobotData {
         this.lastChange = calculateLastChange(newData);
     }
 
-    // lastChange is the difference of the previous price to the current price
     public double getLastChange() {
         return lastChange;
     }

--- a/src/main/java/com/alphatica/genotick/genotick/SimpleEngine.java
+++ b/src/main/java/com/alphatica/genotick/genotick/SimpleEngine.java
@@ -1,6 +1,7 @@
 package com.alphatica.genotick.genotick;
 
 import com.alphatica.genotick.account.Account;
+import com.alphatica.genotick.account.ProfitRecorder;
 import com.alphatica.genotick.breeder.RobotBreeder;
 import com.alphatica.genotick.data.DataSetName;
 import com.alphatica.genotick.data.MainAppData;
@@ -31,7 +32,8 @@ public class SimpleEngine implements Engine {
     private Population population;
     private MainAppData data;
     private final UserOutput output = UserInputOutputFactory.getUserOutput();
-    private final Account account = new Account(BigDecimal.valueOf(100_000L), output);
+    private final ProfitRecorder profitRecorder = new ProfitRecorder();
+    private final Account account = new Account(BigDecimal.valueOf(100_000L), output, profitRecorder);
 
     static Engine getEngine() {
         return new SimpleEngine();

--- a/src/main/java/com/alphatica/genotick/genotick/SimpleEngine.java
+++ b/src/main/java/com/alphatica/genotick/genotick/SimpleEngine.java
@@ -32,7 +32,7 @@ public class SimpleEngine implements Engine {
     private Population population;
     private MainAppData data;
     private final UserOutput output = UserInputOutputFactory.getUserOutput();
-    private final ProfitRecorder profitRecorder = new ProfitRecorder();
+    private final ProfitRecorder profitRecorder = new ProfitRecorder(output);
     private final Account account = new Account(BigDecimal.valueOf(100_000L), output, profitRecorder);
 
     static Engine getEngine() {

--- a/src/main/java/com/alphatica/genotick/genotick/SimpleEngine.java
+++ b/src/main/java/com/alphatica/genotick/genotick/SimpleEngine.java
@@ -141,7 +141,7 @@ public class SimpleEngine implements Engine {
     }
 
     private void updateAccount(List<RobotData> robotDataList) {
-        Map<DataSetName, Double> map = robotDataList.stream().collect(Collectors.toMap(RobotData::getName, RobotData::getLastOpen));
+        Map<DataSetName, Double> map = robotDataList.stream().collect(Collectors.toMap(RobotData::getName, RobotData::getLastPriceOpen));
         account.closeTrades(map);
         account.openTrades(map);
     }

--- a/src/main/java/com/alphatica/genotick/population/Robot.java
+++ b/src/main/java/com/alphatica/genotick/population/Robot.java
@@ -86,7 +86,7 @@ public class Robot implements Serializable {
     public void recordMarketChange(RobotData robotData) {
         ofNullable(current.get(robotData.getName())).ifPresent(prediction -> {
             current.remove(robotData.getName());
-            Outcome outcome = Outcome.getOutcome(prediction, robotData.getLastChange());
+            Outcome outcome = Outcome.getOutcome(prediction, robotData.getLastPriceChange());
             totalOutcomes++;
             if(outcome != Outcome.OUT) {
                 totalPredictions++;

--- a/src/main/java/com/alphatica/genotick/processor/SimpleProcessor.java
+++ b/src/main/java/com/alphatica/genotick/processor/SimpleProcessor.java
@@ -334,7 +334,7 @@ public class SimpleProcessor extends Processor implements RobotExecutor {
         int reg = ins.getRegister();
         int offset = fixOffset(ins.getDataOffsetIndex());
         int column = fixColumn(ins.getDataColumnIndex());
-        registers[reg] = data.getData(column, offset);
+        registers[reg] = data.getPriceData(column, offset);
     }
 
 
@@ -342,7 +342,7 @@ public class SimpleProcessor extends Processor implements RobotExecutor {
     public void execute(MoveDataToVariable ins) {
         int offset = fixOffset(ins.getDataOffsetIndex());
         int column = fixColumn(ins.getDataColumnIndex());
-        double value = data.getData(column, offset);
+        double value = data.getPriceData(column, offset);
         instructionList.setVariable(ins.getVariableArgument(),value);
     }
 
@@ -351,14 +351,14 @@ public class SimpleProcessor extends Processor implements RobotExecutor {
         int reg = ins.getRegister();
         int varOffset = getRelativeOffset(ins);
         int column = fixColumn(ins.getDataColumnIndex());
-        registers[reg] = data.getData(column, varOffset);
+        registers[reg] = data.getPriceData(column, varOffset);
     }
 
     @Override
     public void execute(MoveRelativeDataToVariable ins) {
         int varOffset = getRelativeOffset(ins);
         int column = fixColumn(ins.getDataColumnIndex());
-        double value = data.getData(column, varOffset);
+        double value = data.getPriceData(column, varOffset);
         instructionList.setVariable(ins.getVariableArgument(), value);
     }
 
@@ -606,7 +606,7 @@ public class SimpleProcessor extends Processor implements RobotExecutor {
     public void execute(NaturalLogarithmOfData ins) {
         int column = fixColumn(ins.getDataColumnIndex());
         int offset = fixOffset(ins.getDataOffsetIndex());
-        double value = Math.log(data.getData(column,offset));
+        double value = Math.log(data.getPriceData(column,offset));
         registers[ins.getRegister()] = value;
     }
 
@@ -653,7 +653,7 @@ public class SimpleProcessor extends Processor implements RobotExecutor {
     private double getSum(int column, int length) {
         double sum = 0;
         for(int i = 0; i < length; i++) {
-            sum += data.getData(column,i);
+            sum += data.getPriceData(column,i);
         }
         return sum;
     }
@@ -773,9 +773,9 @@ public class SimpleProcessor extends Processor implements RobotExecutor {
     public void execute(HighestOfColumn ins) {
         int column = fixColumn(ins.getRegister1());
         int length = fixOffset(registers[ins.getRegister2()]);
-        double highest = data.getData(column,0);
+        double highest = data.getPriceData(column,0);
         for(int i = 1; i < length; i++) {
-            double check = data.getData(column,i);
+            double check = data.getPriceData(column,i);
             if(check > highest) {
                 highest = check;
             }
@@ -787,9 +787,9 @@ public class SimpleProcessor extends Processor implements RobotExecutor {
     public void execute(LowestOfColumn ins) {
         int column = fixColumn(ins.getRegister1());
         int length = fixOffset(registers[ins.getRegister2()]);
-        double lowest = data.getData(column,0);
+        double lowest = data.getPriceData(column,0);
         for(int i = 1; i < length; i++) {
-            double check = data.getData(column,i);
+            double check = data.getPriceData(column,i);
             if(check < lowest) {
                 lowest = check;
             }

--- a/src/main/java/com/alphatica/genotick/ui/ConsoleOutput.java
+++ b/src/main/java/com/alphatica/genotick/ui/ConsoleOutput.java
@@ -44,7 +44,7 @@ class ConsoleOutput implements UserOutput {
 
     @Override
     public void reportAccountOpening(BigDecimal cash) {
-        log(format("Openning account with %s cash", cash.toPlainString()));
+        log(format("Opening account with %s cash", cash.toPlainString()));
     }
 
     @Override
@@ -65,7 +65,7 @@ class ConsoleOutput implements UserOutput {
 
     @Override
     public void reportAccountClosing(BigDecimal cash) {
-        log(format("Account closing with final value %s", scale(cash)));
+        log(format("Closing account with %s cash", scale(cash)));
     }
 
     @Override

--- a/src/test/java/com/alphatica/genotick/account/AccountTest.java
+++ b/src/test/java/com/alphatica/genotick/account/AccountTest.java
@@ -18,12 +18,15 @@ import static org.testng.Assert.assertTrue;
 
 public class AccountTest {
 
+    private static final String NAME_ONE = "one";
+    private static final String NAME_TWO = "two";
+    
     private Account account;
     private BigDecimal initial;
 
-    private final DataSetName name1 = new DataSetName("one");
+    private final DataSetName name1 = new DataSetName(NAME_ONE);
     private final double price1 = 100;
-    private final DataSetName name2 = new DataSetName("two");
+    private final DataSetName name2 = new DataSetName(NAME_TWO);
     private final double price2 = 1000;
     private final Map<DataSetName, Double> map1 = Collections.singletonMap(name1, price1);
     private final Map<DataSetName, Double> map2 = buildMap2();
@@ -41,7 +44,7 @@ public class AccountTest {
     public void init() {
         initial = BigDecimal.valueOf(1_000_000);
         output = new MockUserOutput();
-        profitRecorder = new ProfitRecorder();
+        profitRecorder = new ProfitRecorder(output);
         account = new Account(initial, output, profitRecorder);
     }
 
@@ -63,6 +66,7 @@ public class AccountTest {
         Account acc = new Account(initial, output, profitRecorder);
         acc.closeAccount();
         compare(initial, output.accountClosing);
+        assertEquals(output.message, null);
     }
 
     @Test
@@ -115,6 +119,7 @@ public class AccountTest {
         account.openTrades(map1);
         account.closeAccount();
         assertEquals(initial, account.getCash());
+        assertEquals(output.message, String.format("Win rate for %s: 0,00 %%", NAME_ONE));
     }
 
     @Test
@@ -132,8 +137,8 @@ public class AccountTest {
         account.openTrades(map1);
         account.closeTrades(map1);
         account.closeAccount();
-        BigDecimal closed = account.getCash();
-        assertTrue(initial.equals(closed));
+        assertEquals(initial, account.getCash());
+        assertEquals(output.message, String.format("Win rate for %s: 0,00 %%", NAME_ONE));
     }
 
     @Test
@@ -149,6 +154,7 @@ public class AccountTest {
         account.closeAccount();
         BigDecimal closed = account.getCash();
         compare(closed, initial.multiply(BigDecimal.valueOf(profit)));
+        assertEquals(output.message, String.format("Win rate for %s: 100,00 %%", NAME_TWO));
     }
 
     @Test
@@ -219,6 +225,7 @@ public class AccountTest {
         Prediction prediction;
         DataSetName name;
         Double price;
+        String message;
 
         void clear() {
             accountOpening = null;
@@ -230,6 +237,7 @@ public class AccountTest {
             prediction = null;
             name = null;
             price = Double.NaN;
+            message = null;
         }
 
         @Override
@@ -287,7 +295,7 @@ public class AccountTest {
 
         @Override
         public void infoMessage(String s) {
-
+            message = s;
         }
 
         @Override

--- a/src/test/java/com/alphatica/genotick/account/AccountTest.java
+++ b/src/test/java/com/alphatica/genotick/account/AccountTest.java
@@ -28,6 +28,7 @@ public class AccountTest {
     private final Map<DataSetName, Double> map1 = Collections.singletonMap(name1, price1);
     private final Map<DataSetName, Double> map2 = buildMap2();
     private MockUserOutput output;
+    private ProfitRecorder profitRecorder;
 
     private Map<DataSetName,Double> buildMap2() {
         Map<DataSetName, Double> map = new HashMap<>();
@@ -40,7 +41,8 @@ public class AccountTest {
     public void init() {
         initial = BigDecimal.valueOf(1_000_000);
         output = new MockUserOutput();
-        account = new Account(initial, output);
+        profitRecorder = new ProfitRecorder();
+        account = new Account(initial, output, profitRecorder);
     }
 
     @Test
@@ -58,7 +60,7 @@ public class AccountTest {
 
     @Test
     public void reportsAccountClosing() {
-        Account acc = new Account(initial, output);
+        Account acc = new Account(initial, output, profitRecorder);
         acc.closeAccount();
         compare(initial, output.accountClosing);
     }

--- a/src/test/java/com/alphatica/genotick/account/AccountTest.java
+++ b/src/test/java/com/alphatica/genotick/account/AccountTest.java
@@ -17,16 +17,13 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 public class AccountTest {
-
-    private static final String NAME_ONE = "one";
-    private static final String NAME_TWO = "two";
     
     private Account account;
     private BigDecimal initial;
 
-    private final DataSetName name1 = new DataSetName(NAME_ONE);
+    private final DataSetName name1 = new DataSetName("one");
     private final double price1 = 100;
-    private final DataSetName name2 = new DataSetName(NAME_TWO);
+    private final DataSetName name2 = new DataSetName("two");
     private final double price2 = 1000;
     private final Map<DataSetName, Double> map1 = Collections.singletonMap(name1, price1);
     private final Map<DataSetName, Double> map2 = buildMap2();
@@ -64,6 +61,7 @@ public class AccountTest {
     @Test
     public void reportsAccountClosing() {
         Account acc = new Account(initial, output, profitRecorder);
+        output.clear();
         acc.closeAccount();
         compare(initial, output.accountClosing);
         assertEquals(output.message, null);
@@ -117,9 +115,10 @@ public class AccountTest {
     public void closesTrades() {
         account.addPendingOrder(name1, Prediction.DOWN);
         account.openTrades(map1);
+        output.clear();
         account.closeAccount();
         assertEquals(initial, account.getCash());
-        assertEquals(output.message, String.format("Win rate for %s: 0,00 %%", NAME_ONE));
+        assertEquals(output.message, ProfitRecorder.getNoWinRateFormat(name1));
     }
 
     @Test
@@ -136,9 +135,10 @@ public class AccountTest {
         account.addPendingOrder(name1, Prediction.DOWN);
         account.openTrades(map1);
         account.closeTrades(map1);
+        output.clear();
         account.closeAccount();
         assertEquals(initial, account.getCash());
-        assertEquals(output.message, String.format("Win rate for %s: 0,00 %%", NAME_ONE));
+        assertEquals(output.message, ProfitRecorder.getNoWinRateFormat(name1));
     }
 
     @Test
@@ -151,10 +151,11 @@ public class AccountTest {
         map.put(name1, price1 * profit);
         map.put(name2, price2 * profit);
         account.closeTrades(map);
+        output.clear();
         account.closeAccount();
         BigDecimal closed = account.getCash();
         compare(closed, initial.multiply(BigDecimal.valueOf(profit)));
-        assertEquals(output.message, String.format("Win rate for %s: 100,00 %%", NAME_TWO));
+        assertEquals(output.message, ProfitRecorder.getWinRateFormat(name2, 100.0));
     }
 
     @Test

--- a/src/test/java/com/alphatica/genotick/account/AccountTest.java
+++ b/src/test/java/com/alphatica/genotick/account/AccountTest.java
@@ -129,7 +129,8 @@ public class AccountTest {
         account.addPendingOrder(name1, Prediction.DOWN);
         account.openTrades(map1);
         account.closeTrades(map1);
-        BigDecimal closed = account.closeAccount();
+        account.closeAccount();
+        BigDecimal closed = account.getCash();
         assertTrue(initial.equals(closed));
     }
 
@@ -143,7 +144,8 @@ public class AccountTest {
         map.put(name1, price1 * profit);
         map.put(name2, price2 * profit);
         account.closeTrades(map);
-        BigDecimal closed = account.closeAccount();
+        account.closeAccount();
+        BigDecimal closed = account.getCash();
         compare(closed, initial.multiply(BigDecimal.valueOf(profit)));
     }
 


### PR DESCRIPTION
I wanted to see some more information at the end of a test run. I saw you created a ProfitRecorder class that already has a few features but was nowhere used. I moved it into the Account package and supported its functionality as is. I hope this matches your initial intention.