### PR TITLE
Add settings for simulated profit reinvestment factor

### DIFF
--- a/exampleConfigFile.txt
+++ b/exampleConfigFile.txt
@@ -150,3 +150,6 @@ randomSeed 0
 # [chartMode JFREECHART_SAVE] Save genotick charts in the user's working directory with JFreeChart.
 # [chartMode JFREECHART_DRAW_SAVE] Draw and save genotick charts with JFreeChart.
 chartMode NONE
+
+# The factor of profit to be reinvested for the simulated trade profit
+profitReinvestFactor 1.0

--- a/src/main/java/com/alphatica/genotick/genotick/EngineSettings.java
+++ b/src/main/java/com/alphatica/genotick/genotick/EngineSettings.java
@@ -12,6 +12,7 @@ public class EngineSettings {
     public final boolean requireSymmetricalRobots;
     public final double resultThreshold;
     public final GenoChartMode chartMode;
+    public final double profitReinvestFactor;
     
     public EngineSettings(final MainSettings settings) {
         this.startTimePoint = settings.startTimePoint;
@@ -22,5 +23,6 @@ public class EngineSettings {
         this.requireSymmetricalRobots = settings.requireSymmetricalRobots;
         this.resultThreshold = settings.resultThreshold;
         this.chartMode = settings.chartMode;
+        this.profitReinvestFactor = settings.profitReinvestFactor;
     }
 }

--- a/src/main/java/com/alphatica/genotick/genotick/MainSettings.java
+++ b/src/main/java/com/alphatica/genotick/genotick/MainSettings.java
@@ -46,6 +46,7 @@ public class MainSettings {
     public int ignoreColumns = 0;
     public long randomSeed = DEFAULT_RANDOM_SEED;
     public GenoChartMode chartMode = GenoChartMode.NONE;
+    public double profitReinvestFactor = 1.0;
 
     private MainSettings() {
         String minimumScoreString = System.getenv("GENOTICK_MINIMUM_SCORE");

--- a/src/main/java/com/alphatica/genotick/genotick/MainSettings.java
+++ b/src/main/java/com/alphatica/genotick/genotick/MainSettings.java
@@ -87,10 +87,11 @@ public class MainSettings {
         ensure(minimumOutcomesToAllowBreeding >= 0, atLeastZeroString("Minimum outcomes to allow breeding"));
         ensure(minimumOutcomesBetweenBreeding >= 0, atLeastZeroString("Minimum outcomes between breeding"));
         ensure(minimumScoreToSaveToDisk >= 0, atLeastZeroString("Minimum score to save to disk"));
-        ensure(randomRobotsAtEachUpdate >=0, zeroToOneString("Random Robots at Each Update"));
+        ensure(randomRobotsAtEachUpdate >= 0, zeroToOneString("Random Robots at Each Update"));
         ensure(protectBestRobots >= 0, zeroToOneString("Protect Best Robots"));
         ensure(resultThreshold >= 1,atLeastOneString("Result threshold"));
         ensure(ignoreColumns >= 0, atLeastZeroString("Ignore columns"));
+        ensure(profitReinvestFactor >= 0, atLeastZeroString("Profit reinvest factor"));
     }
 
     private String atLeastZeroString(String s) {

--- a/src/main/java/com/alphatica/genotick/genotick/SimpleEngine.java
+++ b/src/main/java/com/alphatica/genotick/genotick/SimpleEngine.java
@@ -77,7 +77,9 @@ public class SimpleEngine implements Engine {
         this.data = data;
         this.robotDataManager = new RobotDataManager(data, engineSettings.maximumDataOffset);
         this.profitRecorder = new ProfitRecorder(engineSettings.chartMode, output);
-        this.account = new Account(BigDecimal.valueOf(100_000L), output, profitRecorder);
+        BigDecimal deposit = BigDecimal.valueOf(100_000L);
+        BigDecimal reinvestFactor = BigDecimal.valueOf(engineSettings.profitReinvestFactor);
+        this.account = new Account(deposit, reinvestFactor, output, profitRecorder);
         this.sessionResult = sessionResult;
     }
 

--- a/src/main/java/com/alphatica/genotick/ui/ConsoleInput.java
+++ b/src/main/java/com/alphatica/genotick/ui/ConsoleInput.java
@@ -64,6 +64,7 @@ class ConsoleInput extends BasicUserInput {
                 settings.protectBestRobots = getDouble("Protect best robots", settings.protectBestRobots);
                 settings.ignoreColumns = getInteger("Ignore columns for training", settings.ignoreColumns);
                 settings.randomSeed = getLong("Random seed", settings.randomSeed);
+                settings.profitReinvestFactor = getDouble("Profit reinvest factor", settings.profitReinvestFactor);
             }
             setMainSettings(settings);
         }


### PR DESCRIPTION
Hello. This features is just for visualization convenience. We already talked about this a while ago and I recommended to remove the reinvestment of the profit for the account performance simulation. I made the reinvestment a new setting, so users can set it to 0 or 1 (default) or anything else. 1 is the original setting, which reinvests all profits. Personally I highly prefer a setting of 0, because of 2 reasons:

1) it illustrates profit grow linearly and does not overemphasize price movement above the deposit value and does not underemphasize price movements below the deposit value.

I rendered these images with genotick and BTCUSD 2013-2015 data to illustrate:
The linear illustration shows much better that the price crash of Bitcoin did not throw off genotick as much as it seems compared to the non-linear investment.
![genotic](https://user-images.githubusercontent.com/4720891/34046153-5771e26e-e1ac-11e7-8de1-17a78da6e23d.png)

2) In real trading you typically do not reinvest 100% of your profits, because that means your risk grows exponentially and eventually you lose all capital.

See Step 9: Money Management:
http://www.financial-hacker.com/build-better-strategies-part-3-the-development-process/
